### PR TITLE
Make the path to zoxide customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,41 @@
 # smart_workspace_switcher.wezterm
+
 A smart Wezterm workspace switcher inspired by [joshmedeski/t-smart-tmux-session-manager](https://github.com/joshmedeski/t-smart-tmux-session-manager)
+
 ## Usage
+
 💨 Level up your workflow by switching between workspaces ⚡ ***BLAZINGLY FAST*** ⚡ with 1️⃣ keypress, the power of fuzzy finding and zoxide! 💨
 
 ![Demo gif](https://github.com/MLFlexer/smart_workspace_switcher.wezterm/assets/75012728/a4f82fcf-5304-4891-a1e2-346767678dc6)
 
-
 ## Dependencies
+
 * zoxide
 
 ### Setup
-1. require the plugin:
-```lua
-local wezterm = require("wezterm")
-local workspace_switcher = wezterm.plugin.require("https://github.com/MLFlexer/smart_workspace_switcher.wezterm")
-```
 
-2. Add a keybinding and formatter for Workspace labels:
-```lua
-workspace_switcher.apply_to_config(config, "b", "ALT", function(label)
-  return wezterm.format({
-    -- { Attribute = { Italic = true } },
-    -- { Foreground = { Color = "green" } },
-    -- { Background = { Color = "black" } },
-    { Text = "󱂬: " .. label },
-  })
-end)
-```
+1. require the plugin:
+
+    ```lua
+    local wezterm = require("wezterm")
+    local workspace_switcher = wezterm.plugin.require("https://github.com/MLFlexer/smart_workspace_switcher.wezterm")
+    ```
+
+2. Optionally set the path to Zoxide:
+
+    ```lua
+    workspace_switcher.set_zoxide_path("/custom/path/zoxide)
+    ```
+
+3. Add a keybinding and formatter for Workspace labels:
+
+    ```lua
+    workspace_switcher.apply_to_config(config, "b", "ALT", function(label)
+      return wezterm.format({
+        -- { Attribute = { Italic = true } },
+        -- { Foreground = { Color = "green" } },
+        -- { Background = { Color = "black" } },
+        { Text = "󱂬: " .. label },
+      })
+    end)
+    ```

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -44,7 +44,7 @@ local function workspace_switcher(workspace_formatter)
 								}),
 								inner_pane
 							)
-							window:set_right_status(window:active_workspace())
+							window:set_right_status(window:active_workspace() .. "  ")
 							-- increment path score
 							wezterm.run_child_process({
 								"zoxide",
@@ -59,7 +59,7 @@ local function workspace_switcher(workspace_formatter)
 								}),
 								inner_pane
 							)
-							window:set_right_status(window:active_workspace())
+							window:set_right_status(window:active_workspace() .. "  ")
 						end
 					end
 				end),

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,8 +1,9 @@
 local wezterm = require("wezterm")
 local act = wezterm.action
+local zoxide_path = "zoxide"
 
 local function get_zoxide_workspaces(workspace_formatter)
-	local _, stdout, _ = wezterm.run_child_process({ "zoxide", "query", "-l" })
+	local _, stdout, _ = wezterm.run_child_process({ zoxide_path, "query", "-l" })
 
 	local workspace_table = {}
 	for _, workspace in ipairs(wezterm.mux.get_workspace_names()) do
@@ -92,4 +93,11 @@ local function apply_to_config(config, key, mods, formatter)
 	})
 end
 
-return { apply_to_config = apply_to_config }
+local function set_zoxide_path(path)
+	zoxide_path = path
+end
+
+return {
+	apply_to_config = apply_to_config,
+	set_zoxide_path = set_zoxide_path
+}


### PR DESCRIPTION
In some cases (.e.g a nix-based environment) zoxide might not be on the system path.

This allows the config to set the path to Zoxide prior to applying the configuration change.