### PR TITLE
Add extra_args for zoxide query command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ Add custom keybinding
     }
   }
   ```
+
+##### Additional filtering
+
+Users may also choose to include `extra_args` in the call to `switch_workspace`. The string contents of this value are appended to the call to `zoxide query -l`. This can be used to further filter the results of the query. For example, imagine one has a predefined list of projects from which they wish to select. It might be a file, ~/.projects, with contents like:
+
+```
+/Users/you/projects/gitlab.com/foo/bar
+/Users/you/projects/github.com/MLFlexer/smart_workspace_switcher.wezterm
+```
+
+If you want your project switcher only to select projects from this list, but still make use of the zoxide query ordering, you can call the plugin as:
+
+  ```lua
+  config.keys = {
+    -- ...
+    -- your other keybindings
+    {
+    key = "s",
+    mods = "ALT",
+    action = workspace_switcher.switch_workspace(" | rg -Fxf ~/.projects"),
+    }
+  }
+  ```
+
 #### Update right-status with the path
 Adding the path as a part of the right-status can be done via. [update-right-status](https://wezfurlong.org/wezterm/config/lua/window-events/update-right-status.html) event
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -14,7 +14,7 @@ local workspace_formatter = function(label)
 	})
 end
 
----@param extra_args string
+---@param extra_args? string
 ---@return { id: string, label: string }[]
 local function get_zoxide_workspaces(extra_args)
   if extra_args == nil then extra_args = "" end
@@ -37,7 +37,7 @@ local function get_zoxide_workspaces(extra_args)
 	return workspace_table
 end
 
----@param extra_args string
+---@param extra_args? string
 ---@return action_callback
 local function workspace_switcher(extra_args)
 	return wezterm.action_callback(function(window, pane)

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -14,9 +14,11 @@ local workspace_formatter = function(label)
 	})
 end
 
+---@param extra_args string
 ---@return { id: string, label: string }[]
-local function get_zoxide_workspaces()
-	local _, stdout, _ = wezterm.run_child_process({ os.getenv("SHELL"), "-c", zoxide_path .. " query -l" })
+local function get_zoxide_workspaces(extra_args)
+  if extra_args == nil then extra_args = "" end
+	local _, stdout, _ = wezterm.run_child_process({ os.getenv("SHELL"), "-c", zoxide_path .. " query -l " .. extra_args })
 
 	local workspace_table = {}
 	for _, workspace in ipairs(wezterm.mux.get_workspace_names()) do
@@ -35,10 +37,11 @@ local function get_zoxide_workspaces()
 	return workspace_table
 end
 
+---@param extra_args string
 ---@return action_callback
-local function workspace_switcher()
+local function workspace_switcher(extra_args)
 	return wezterm.action_callback(function(window, pane)
-		local workspaces = get_zoxide_workspaces()
+		local workspaces = get_zoxide_workspaces(extra_args)
 
 		window:perform_action(
 			act.InputSelector({


### PR DESCRIPTION
This allows me to call `switch_workspace(" | rg -Fxf ~/.projects")` to filter the list further to only those candidates I want to include in the selection, while maintaining the query ordering behavior benefits of using zoxide in the first place. But this could be used for any additional argument somebody wanted to use for the query. Of course, it is likely none or few will find this useful, but it is unobtrusive. If you reject it, I completely understand, but this is useful for me.

As an aside, if you're interested in how I generate this list, I use [this script](https://github.com/theherk/commons/blob/main/bin/repocache.sh) to find all git roots in my projects directory and populate a file that is just a list of these for filtering.